### PR TITLE
Use `make -C compiler` to build cpp

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,4 +17,4 @@ wasm:
     @cp target/wasm32-unknown-emscripten/release/*.wasm* docs/.
 
 cpp:
-    cd compiler && make && cd ..
+    make -C compiler


### PR DESCRIPTION
Make can be told to change directories with the `-C` flag. Same effect, but a little bit nicer than `cd compiler && make`